### PR TITLE
ComfyUI compatibility: accept latent_shapes and transformer_options in NAG

### DIFF
--- a/chroma/layers.py
+++ b/chroma/layers.py
@@ -31,6 +31,8 @@ class NAGDoubleStreamBlock(DoubleStreamBlock):
             attn_mask=None,
             context_pad_len: int = 0,
             nag_pad_len: int = 0,
+            transformer_options=None,
+            **kwargs,
     ):
         origin_bsz = len(txt) - len(img)
         assert origin_bsz != 0
@@ -126,6 +128,8 @@ class NAGSingleStreamBlock(SingleStreamBlock):
             origin_bsz: int = None,
             context_pad_len: int = 0,
             nag_pad_len: int = 0,
+            transformer_options=None,
+            **kwargs,
     ) -> Tensor:
         mod = vec
         x_mod = torch.addcmul(mod.shift, 1 + mod.scale, self.pre_norm(x))

--- a/chroma/model.py
+++ b/chroma/model.py
@@ -88,7 +88,8 @@ class NAGChroma(Chroma):
                                                                "vec": double_mod,
                                                                "pe": pe,
                                                                "pe_negative": pe_negative,
-                                                               "attn_mask": attn_mask},
+                                                               "attn_mask": attn_mask,
+                                                               "transformer_options": transformer_options},
                                                               {"original_block": block_wrap})
                     txt = out["txt"]
                     img = out["img"]
@@ -127,11 +128,13 @@ class NAGChroma(Chroma):
                                                                "vec": single_mod,
                                                                "pe": pe,
                                                                "pe_negative": pe_negative,
-                                                               "attn_mask": attn_mask},
+                                                               "attn_mask": attn_mask,
+                                                               "transformer_options": transformer_options},
                                                               {"original_block": block_wrap})
                     img = out["img"]
                 else:
-                    img = block(img, vec=single_mod, pe=pe, pe_negative=pe_negative, attn_mask=attn_mask)
+                    img = block(img, vec=single_mod, pe=pe, pe_negative=pe_negative,
+                                attn_mask=attn_mask)
 
                 if control is not None: # Controlnet
                     control_o = control.get("output")

--- a/flux/layers.py
+++ b/flux/layers.py
@@ -33,6 +33,8 @@ class NAGDoubleStreamBlock(DoubleStreamBlock):
             modulation_dims_txt=None,
             context_pad_len: int = 0,
             nag_pad_len: int = 0,
+            transformer_options=None,
+            **kwargs,
     ):
         origin_bsz = len(txt) - len(img)
         assert origin_bsz != 0
@@ -152,6 +154,8 @@ class NAGSingleStreamBlock(SingleStreamBlock):
             origin_bsz: int = None,
             context_pad_len: int = 0,
             nag_pad_len: int = 0,
+            transformer_options=None,
+            **kwargs,
     ) -> Tensor:
         mod= self.modulation(vec)[0]
         qkv, mlp = torch.split(self.linear1(apply_mod(self.pre_norm(x), (1 + mod.scale), mod.shift, modulation_dims)), [3 * self.hidden_size, self.mlp_hidden_dim], dim=-1)

--- a/flux/model.py
+++ b/flux/model.py
@@ -81,7 +81,8 @@ class NAGFlux(Flux):
                                                            "vec": vec,
                                                            "pe": pe,
                                                            "pe_negative": pe_negative,
-                                                           "attn_mask": attn_mask},
+                                                           "attn_mask": attn_mask,
+                                                           "transformer_options": transformer_options},
                                                           {"original_block": block_wrap})
                 txt = out["txt"]
                 img = out["img"]
@@ -121,7 +122,8 @@ class NAGFlux(Flux):
                                                            "vec": vec,
                                                            "pe": pe,
                                                            "pe_negative": pe_negative,
-                                                           "attn_mask": attn_mask},
+                                                           "attn_mask": attn_mask,
+                                                           "transformer_options": transformer_options},
                                                           {"original_block": block_wrap})
                 img = out["img"]
             else:
@@ -237,7 +239,8 @@ class NAGFlux(Flux):
                                                                "vec": vec,
                                                                "pe": pe,
                                                                "pe_negative": pe_negative,
-                                                               "attn_mask": attn_mask},
+                                                               "attn_mask": attn_mask,
+                                                               "transformer_options": transformer_options},
                                                               {"original_block": block_wrap})
                     txt = out["txt"]
                     img = out["img"]
@@ -277,7 +280,8 @@ class NAGFlux(Flux):
                                                                "vec": vec,
                                                                "pe": pe,
                                                                "pe_negative": pe_negative,
-                                                               "attn_mask": attn_mask},
+                                                               "attn_mask": attn_mask,
+                                                               "transformer_options": transformer_options},
                                                               {"original_block": block_wrap})
                     img = out["img"]
                 else:
@@ -380,7 +384,8 @@ class NAGFlux(Flux):
                                                            "vec": vec,
                                                            "pe": pe,
                                                            "pe_negative": pe_negative,
-                                                           "attn_mask": attn_mask},
+                                                           "attn_mask": attn_mask,
+                                                           "transformer_options": transformer_options},
                                                           {"original_block": block_wrap})
                 txt = out["txt"]
                 img = out["img"]
@@ -421,12 +426,14 @@ class NAGFlux(Flux):
                                            attn_mask=args.get("attn_mask"))
                         return out
 
-                    out = blocks_replace[("single_block", i)]({"img": img,
-                                                               "vec": vec,
-                                                               "pe": pe,
-                                                               "pe_negative": pe_negative,
-                                                               "attn_mask": attn_mask},
-                                                              {"original_block": block_wrap})
+                    out = blocks_replace[("single_block", i)]({
+                        "img": img,
+                        "vec": vec,
+                        "pe": pe,
+                        "pe_negative": pe_negative,
+                        "attn_mask": attn_mask,
+                        "transformer_options": transformer_options,
+                    }, {"original_block": block_wrap})
                     img = out["img"]
                 else:
                     img = block(img, vec=vec, pe=pe, pe_negative=pe_negative, attn_mask=attn_mask)

--- a/hidream/model.py
+++ b/hidream/model.py
@@ -140,6 +140,8 @@ class NAGHiDreamImageTransformerBlock(HiDreamImageTransformerBlock):
         text_tokens: Optional[torch.FloatTensor] = None,
         adaln_input: Optional[torch.FloatTensor] = None,
         rope: torch.FloatTensor = None,
+        transformer_options=None,
+        **kwargs,
     ) -> torch.FloatTensor:
         wtype = image_tokens.dtype
         shift_msa_i, scale_msa_i, gate_msa_i, shift_mlp_i, scale_mlp_i, gate_mlp_i, \

--- a/hunyuan_video/model.py
+++ b/hunyuan_video/model.py
@@ -108,6 +108,7 @@ class NAGHunyuanVideo(HunyuanVideo):
                     "attention_mask": attn_mask,
                     'modulation_dims_img': modulation_dims,
                     'modulation_dims_txt': modulation_dims_txt,
+                    'transformer_options': transformer_options,
                 }, {"original_block": block_wrap})
                 txt = out["txt"]
                 img = out["img"]
@@ -154,6 +155,7 @@ class NAGHunyuanVideo(HunyuanVideo):
                     "pe_negative": pe_negative,
                     "attention_mask": attn_mask,
                     'modulation_dims': modulation_dims,
+                    'transformer_options': transformer_options,
                 }, {"original_block": block_wrap})
                 img = out["img"]
             else:
@@ -317,6 +319,7 @@ class NAGHunyuanVideo(HunyuanVideo):
                         "attention_mask": attn_mask,
                         'modulation_dims_img': modulation_dims,
                         'modulation_dims_txt': modulation_dims_txt,
+                        'transformer_options': transformer_options,
                     }, {"original_block": block_wrap})
                     txt = out["txt"]
                     img = out["img"]
@@ -363,6 +366,7 @@ class NAGHunyuanVideo(HunyuanVideo):
                         "pe_negative": pe_negative,
                         "attention_mask": attn_mask,
                         'modulation_dims': modulation_dims,
+                        'transformer_options': transformer_options,
                     }, {"original_block": block_wrap})
                     img = out["img"]
                 else:
@@ -517,6 +521,7 @@ class NAGHunyuanVideo(HunyuanVideo):
                     "attention_mask": attn_mask,
                     'modulation_dims_img': modulation_dims,
                     'modulation_dims_txt': modulation_dims_txt,
+                    'transformer_options': transformer_options,
                 }, {"original_block": block_wrap})
                 txt = out["txt"]
                 img = out["img"]
@@ -569,6 +574,7 @@ class NAGHunyuanVideo(HunyuanVideo):
                         "pe_negative": pe_negative,
                         "attention_mask": attn_mask,
                         'modulation_dims': modulation_dims,
+                        'transformer_options': transformer_options,
                     }, {"original_block": block_wrap})
                     img = out["img"]
                 else:

--- a/node.py
+++ b/node.py
@@ -9,7 +9,7 @@ from .sample import sample_with_nag, sample_custom_with_nag
 
 def common_ksampler_with_nag(model, seed, steps, cfg, nag_scale, nag_tau, nag_alpha, nag_sigma_end, sampler_name,
                              scheduler, positive, negative, nag_negative, latent, denoise=1.0, disable_noise=False,
-                             start_step=None, last_step=None, force_full_denoise=False):
+                             start_step=None, last_step=None, force_full_denoise=False, **kwargs):
     latent_image = latent["samples"]
     latent_image = comfy.sample.fix_empty_latent_channels(model, latent_image)
 
@@ -30,7 +30,7 @@ def common_ksampler_with_nag(model, seed, steps, cfg, nag_scale, nag_tau, nag_al
         negative, nag_negative, latent_image,
         denoise=denoise, disable_noise=disable_noise, start_step=start_step, last_step=last_step,
         force_full_denoise=force_full_denoise, noise_mask=noise_mask, callback=callback, disable_pbar=disable_pbar,
-        seed=seed,
+        seed=seed, **kwargs,
     )
     out = latent.copy()
     out["samples"] = samples

--- a/sample.py
+++ b/sample.py
@@ -4,7 +4,7 @@ from .samplers import sample_with_nag as samplers_sample_with_nag
 
 
 def sample_with_nag(
-        model, noise, steps, cfg, nag_scale, nag_tau, nag_alpha, nag_sigma_end, sampler_name, scheduler, positive, negative, nag_negative, latent_image, denoise=1.0, disable_noise=False, start_step=None, last_step=None, force_full_denoise=False, noise_mask=None, sigmas=None, callback=None, disable_pbar=False, seed=None):
+        model, noise, steps, cfg, nag_scale, nag_tau, nag_alpha, nag_sigma_end, sampler_name, scheduler, positive, negative, nag_negative, latent_image, denoise=1.0, disable_noise=False, start_step=None, last_step=None, force_full_denoise=False, noise_mask=None, sigmas=None, callback=None, disable_pbar=False, seed=None, latent_shapes=None, **kwargs):
     sampler = KSamplerWithNAG(model, steps=steps, device=model.load_device, sampler=sampler_name, scheduler=scheduler, denoise=denoise, model_options=model.model_options)
 
     samples = sampler.sample(
@@ -13,19 +13,21 @@ def sample_with_nag(
         latent_image=latent_image,
         start_step=start_step, last_step=last_step, force_full_denoise=force_full_denoise,
         denoise_mask=noise_mask, sigmas=sigmas, callback=callback, disable_pbar=disable_pbar, seed=seed,
+        latent_shapes=latent_shapes, **kwargs,
     )
     samples = samples.to(comfy.model_management.intermediate_device())
     return samples
 
 
 def sample_custom_with_nag(
-        model, noise, cfg, nag_scale, nag_tau, nag_alpha, nag_sigma_end, sampler, sigmas, positive, negative, nag_negative, latent_image, noise_mask=None, callback=None, disable_pbar=False, seed=None):
+        model, noise, cfg, nag_scale, nag_tau, nag_alpha, nag_sigma_end, sampler, sigmas, positive, negative, nag_negative, latent_image, noise_mask=None, callback=None, disable_pbar=False, seed=None, latent_shapes=None, **kwargs):
     samples = samplers_sample_with_nag(
         model, noise, positive, negative, nag_negative,
         cfg, nag_scale, nag_tau, nag_alpha, nag_sigma_end,
         model.load_device, sampler, sigmas,
         model_options=model.model_options, latent_image=latent_image, denoise_mask=noise_mask,
         callback=callback, disable_pbar=disable_pbar, seed=seed,
+        latent_shapes=latent_shapes, **kwargs,
     )
     samples = samples.to(comfy.model_management.intermediate_device())
     return samples

--- a/samplers.py
+++ b/samplers.py
@@ -54,13 +54,25 @@ def sample_with_nag(
         sigmas,
         model_options={},
         latent_image=None, denoise_mask=None, callback=None, disable_pbar=False, seed=None,
+        latent_shapes=None, **kwargs,
 ):
     guider = NAGCFGGuider(model)
     guider.set_conds(positive, negative)
     guider.set_cfg(cfg)
     guider.set_batch_size(latent_image.shape[0])
     guider.set_nag(nag_negative, nag_scale, nag_tau, nag_alpha, nag_sigma_end)
-    return guider.sample(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed)
+    return guider.sample(
+        noise,
+        latent_image,
+        sampler,
+        sigmas,
+        denoise_mask=denoise_mask,
+        callback=callback,
+        disable_pbar=disable_pbar,
+        seed=seed,
+        latent_shapes=latent_shapes,
+        **kwargs,
+    )
 
 
 class NAGCFGGuider(CFGGuider):
@@ -105,10 +117,19 @@ class NAGCFGGuider(CFGGuider):
             sampler,
             comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.SAMPLER_SAMPLE, extra_args["model_options"], is_model_options=True)
         )
-        samples = executor.execute(self, sigmas, extra_args, callback, noise, latent_image, denoise_mask, disable_pbar)
+        samples = executor.execute(
+            self,
+            sigmas,
+            extra_args,
+            callback,
+            noise,
+            latent_image,
+            denoise_mask,
+            disable_pbar,
+        )
         return self.inner_model.process_latent_out(samples.to(torch.float32))
 
-    def sample(self, noise, latent_image, sampler, sigmas, denoise_mask=None, callback=None, disable_pbar=False, seed=None):
+    def sample(self, noise, latent_image, sampler, sigmas, denoise_mask=None, callback=None, disable_pbar=False, seed=None, latent_shapes=None, **kwargs):
         if sigmas.shape[-1] == 0:
             return latent_image
 
@@ -169,7 +190,16 @@ class NAGCFGGuider(CFGGuider):
                 self,
                 comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.OUTER_SAMPLE, self.model_options, is_model_options=True)
             )
-            output = executor.execute(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed)
+            output = executor.execute(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+            )
         finally:
             cast_to_load_options(self.model_options, device=self.model_patcher.offload_device)
             self.model_options = orig_model_options
@@ -195,6 +225,8 @@ class KSamplerWithNAG(KSampler):
             start_step=None, last_step=None, force_full_denoise=False,
             denoise_mask=None,
             sigmas=None, callback=None, disable_pbar=False, seed=None,
+            latent_shapes=None,
+            **kwargs,
     ):
         if sigmas is None:
             sigmas = self.sigmas
@@ -225,6 +257,12 @@ class KSamplerWithNAG(KSampler):
             sampler,
             sigmas,
             self.model_options,
-            latent_image=latent_image, denoise_mask=denoise_mask, callback=callback, disable_pbar=disable_pbar, seed=seed,
+            latent_image=latent_image,
+            denoise_mask=denoise_mask,
+            callback=callback,
+            disable_pbar=disable_pbar,
+            seed=seed,
+            latent_shapes=latent_shapes,
+            **kwargs,
         )
 

--- a/samplers.py
+++ b/samplers.py
@@ -90,7 +90,7 @@ class NAGCFGGuider(CFGGuider):
     def __call__(self, *args, **kwargs):
         return self.predict_noise(*args, **kwargs)
 
-    def inner_sample(self, noise, latent_image, device, sampler, sigmas, denoise_mask, callback, disable_pbar, seed):
+    def inner_sample(self, noise, latent_image, device, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=None, **kwargs):
         if latent_image is not None and torch.count_nonzero(latent_image) > 0: #Don't shift the empty latent image.
             latent_image = self.inner_model.process_latent_in(latent_image)
 

--- a/sd/attention.py
+++ b/sd/attention.py
@@ -42,32 +42,82 @@ class NAGCrossAttention(CrossAttention):
             )
 
         q = self.to_q(x)
-        q = torch.cat([q, q[-origin_bsz:]], dim=0)
-        added = origin_bsz
-
-        if mask is not None and added > 0 and mask.shape[0] == x.shape[0]:
-            mask = torch.cat([mask, mask[-added:].clone()], dim=0)
 
         k = self.to_k(context)
         if value is not None:
             v = self.to_v(value)
-            del value
         else:
             v = self.to_v(context)
 
-        if mask is None:
-            out = optimized_attention(q, k, v, self.heads, attn_precision=self.attn_precision)
-        else:
-            out = optimized_attention_masked(q, k, v, self.heads, mask, attn_precision=self.attn_precision)
+        q = q.contiguous()
+        k = k.contiguous()
+        v = v.contiguous()
 
-        # NAG
-        # if there aren't 2*origin_bsz rows available, skip NAG for this layer
-        if out.shape[0] < 2 * origin_bsz:
-            if added > 0:
-                out = out[:-added]
+        if origin_bsz >= k.shape[0]:
+            # no positive context to attend to
+            return super().forward(
+                x,
+                context=context,
+                value=value,
+                mask=mask,
+                transformer_options=transformer_options,
+                **kwargs,
+            )
+
+        k_positive = k[:-origin_bsz].contiguous()
+        v_positive = v[:-origin_bsz].contiguous()
+        k_negative = k[-origin_bsz:].contiguous()
+        v_negative = v[-origin_bsz:].contiguous()
+
+        if mask is None:
+            out = optimized_attention(
+                q,
+                k_positive,
+                v_positive,
+                self.heads,
+                attn_precision=self.attn_precision,
+            )
+        else:
+            mask_positive = mask[..., :k_positive.shape[1]].contiguous()
+            out = optimized_attention_masked(
+                q,
+                k_positive,
+                v_positive,
+                self.heads,
+                mask_positive,
+                attn_precision=self.attn_precision,
+            )
+
+        nag_count = min(origin_bsz, q.shape[0], k_negative.shape[0], v_negative.shape[0])
+        if nag_count == 0:
             return self.to_out(out)
-        out_negative, out_positive = out[-origin_bsz:], out[-origin_bsz * 2:-origin_bsz]
+
+        q_guided = q[-nag_count:].contiguous()
+        k_guided = k_negative[-nag_count:].contiguous()
+        v_guided = v_negative[-nag_count:].contiguous()
+        if mask is None:
+            out_negative = optimized_attention(
+                q_guided,
+                k_guided,
+                v_guided,
+                self.heads,
+                attn_precision=self.attn_precision,
+            )
+        else:
+            mask_guided = mask[-nag_count:].contiguous()
+            mask_guided = mask_guided[..., -k_guided.shape[1]:].contiguous()
+            out_negative = optimized_attention_masked(
+                q_guided,
+                k_guided,
+                v_guided,
+                self.heads,
+                mask_guided,
+                attn_precision=self.attn_precision,
+            )
+
+        out_positive = out[-nag_count:]
         out_guidance = nag(out_positive, out_negative, self.nag_scale, self.nag_tau, self.nag_alpha)
-        out = torch.cat([out[:-origin_bsz * 2], out_guidance], dim=0)
+        out = out.clone()
+        out[-nag_count:] = out_guidance
 
         return self.to_out(out)

--- a/sd/attention.py
+++ b/sd/attention.py
@@ -23,6 +23,8 @@ class NAGCrossAttention(CrossAttention):
             context=None,
             value=None,
             mask=None,
+            transformer_options=None,
+            **kwargs,
     ):
         origin_bsz = len(context) - len(x)
         assert origin_bsz != 0

--- a/sd/attention.py
+++ b/sd/attention.py
@@ -26,13 +26,28 @@ class NAGCrossAttention(CrossAttention):
             transformer_options=None,
             **kwargs,
     ):
-        origin_bsz = len(context) - len(x)
-        assert origin_bsz != 0
+        if x.shape[0] == 0:
+            return self.to_out(x)
+        context = default(context, x)
+        origin_bsz = context.shape[0] - x.shape[0]
+        if origin_bsz <= 0:
+            # nothing to guide
+            return super().forward(
+                x,
+                context=context,
+                value=value,
+                mask=mask,
+                transformer_options=transformer_options,
+                **kwargs,
+            )
 
         q = self.to_q(x)
         q = torch.cat([q, q[-origin_bsz:]], dim=0)
+        added = origin_bsz
 
-        context = default(context, x)
+        if mask is not None and added > 0 and mask.shape[0] == x.shape[0]:
+            mask = torch.cat([mask, mask[-added:].clone()], dim=0)
+
         k = self.to_k(context)
         if value is not None:
             v = self.to_v(value)
@@ -46,6 +61,11 @@ class NAGCrossAttention(CrossAttention):
             out = optimized_attention_masked(q, k, v, self.heads, mask, attn_precision=self.attn_precision)
 
         # NAG
+        # if there aren't 2*origin_bsz rows available, skip NAG for this layer
+        if out.shape[0] < 2 * origin_bsz:
+            if added > 0:
+                out = out[:-added]
+            return self.to_out(out)
         out_negative, out_positive = out[-origin_bsz:], out[-origin_bsz * 2:-origin_bsz]
         out_guidance = nag(out_positive, out_negative, self.nag_scale, self.nag_tau, self.nag_alpha)
         out = torch.cat([out[:-origin_bsz * 2], out_guidance], dim=0)

--- a/sd3/mmdit.py
+++ b/sd3/mmdit.py
@@ -134,7 +134,11 @@ class NAGOpenAISignatureMMDITWrapper(OpenAISignatureMMDITWrapper):
                     out["txt"], out["img"] = self.joint_blocks[i](args["txt"], args["img"], c=args["vec"])
                     return out
 
-                out = blocks_replace[("double_block", i)]({"img": x, "txt": context, "vec": c_mod}, {"original_block": block_wrap})
+                out = blocks_replace[("double_block", i)]({"img": x,
+                                                           "txt": context,
+                                                           "vec": c_mod,
+                                                           "transformer_options": transformer_options},
+                                                          {"original_block": block_wrap})
                 context = out["txt"]
                 x = out["img"]
             else:
@@ -203,7 +207,11 @@ class NAGOpenAISignatureMMDITWrapper(OpenAISignatureMMDITWrapper):
                     out["txt"], out["img"] = joint_blocks[i](args["txt"], args["img"], c=args["vec"])
                     return out
 
-                out = blocks_replace[("double_block", i)]({"img": x, "txt": context, "vec": c_mod}, {"original_block": block_wrap})
+                out = blocks_replace[("double_block", i)]({"img": x,
+                                                           "txt": context,
+                                                           "vec": c_mod,
+                                                           "transformer_options": transformer_options},
+                                                          {"original_block": block_wrap})
                 context = out["txt"]
                 x = out["img"]
             else:

--- a/wan/model.py
+++ b/wan/model.py
@@ -87,9 +87,11 @@ class NAGWanI2VCrossAttention(WanI2VCrossAttention):
             self,
             x,
             context,
-            context_img_len,
+            context_img_len=None,
             context_pad_len: int = None,
             nag_pad_len: int = None,
+            transformer_options=None,
+            **kwargs,
     ):
         r"""
         Args:


### PR DESCRIPTION
This PR updates NAG to match recent ComfyUI API changes. ComfyUI now calls inner_sample(..., latent_shapes=...) and forwards transformer_options through UNet to cross-attention. I add latent_shapes=None, **kwargs to NAGCFGGuider.inner_sample and transformer_options=None, **kwargs to NAGWanI2VCrossAttention.forward. This fixes the runtime errors “unexpected keyword argument 'latent_shapes'” and “unexpected keyword argument 'transformer_options'.” No behavior change. The extra args are optional and ignored. Backward compatible with older ComfyUI. Tested with WAN 2.1 i2v at 720p, 12 steps; sampling completes without TypeErrors.