### PR TITLE
Add Z-Image (Lumina2/NextDiT) support 

### DIFF
--- a/lumina2/attention.py
+++ b/lumina2/attention.py
@@ -32,7 +32,7 @@ class NAGJointAttention(JointAttention):
         bsz, seqlen, _ = x.shape
 
         # Retrieve image token length injected by NAGNextDiT
-        img_len = transformer_options.get("nag_img_token_len", 0)
+        img_len = getattr(self, '_nag_img_token_len', 0)
 
         # Safety fallback: if NAG is not active or odd batch size, run standard
         if bsz % 2 != 0 or bsz < 2 or img_len == 0:

--- a/lumina2/attention.py
+++ b/lumina2/attention.py
@@ -1,0 +1,115 @@
+import torch
+from comfy.ldm.lumina.model import JointAttention, optimized_attention_masked
+from comfy.ldm.flux.math import apply_rope
+from ..utils import nag
+
+class NAGJointAttention(JointAttention):
+    def __init__(
+            self,
+            *args,
+            nag_scale: float = 1,
+            nag_tau: float = 2.5,
+            nag_alpha: float = 0.25,
+            **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.nag_scale = nag_scale
+        self.nag_tau = nag_tau
+        self.nag_alpha = nag_alpha
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_mask: torch.Tensor,
+        freqs_cis: torch.Tensor,
+        transformer_options={},
+    ) -> torch.Tensor:
+        
+        # Standard checks
+        if x.shape[0] == 0:
+            return self.out(x)
+
+        bsz, seqlen, _ = x.shape
+
+        # Retrieve image token length injected by NAGNextDiT
+        img_len = transformer_options.get("nag_img_token_len", 0)
+
+        # Safety fallback: if NAG is not active or odd batch size, run standard
+        if bsz % 2 != 0 or bsz < 2 or img_len == 0:
+            return super().forward(x, x_mask, freqs_cis, transformer_options)
+
+        origin_bsz = bsz // 2
+
+        # Project Q, K, V
+        xq, xk, xv = torch.split(
+            self.qkv(x),
+            [
+                self.n_local_heads * self.head_dim,
+                self.n_local_kv_heads * self.head_dim,
+                self.n_local_kv_heads * self.head_dim,
+            ],
+            dim=-1,
+        )
+
+        xq = xq.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+        xk = xk.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+        xv = xv.view(bsz, seqlen, self.n_local_kv_heads, self.head_dim)
+
+        xq = self.q_norm(xq)
+        xk = self.k_norm(xk)
+
+        xq, xk = apply_rope(xq, xk, freqs_cis)
+
+        n_rep = self.n_local_heads // self.n_local_kv_heads
+        if n_rep >= 1:
+            xk = xk.unsqueeze(3).repeat(1, 1, 1, n_rep, 1).flatten(2, 3)
+            xv = xv.unsqueeze(3).repeat(1, 1, 1, n_rep, 1).flatten(2, 3)
+
+        # Split into Positive and Negative batches
+        xq_pos, xq_neg = xq.split(origin_bsz)
+        xk_pos, xk_neg = xk.split(origin_bsz)
+        xv_pos, xv_neg = xv.split(origin_bsz)
+
+        x_mask_pos = x_mask
+        x_mask_neg = x_mask
+        if x_mask is not None and x_mask.shape[0] == bsz:
+            x_mask_pos = x_mask[:origin_bsz]
+            x_mask_neg = x_mask[origin_bsz:]
+
+        # Attention Calculation
+        out_positive = optimized_attention_masked(
+            xq_pos.movedim(1, 2), xk_pos.movedim(1, 2), xv_pos.movedim(1, 2),
+            self.n_local_heads, x_mask_pos, skip_reshape=True, transformer_options=transformer_options
+        )
+
+        out_negative = optimized_attention_masked(
+            xq_neg.movedim(1, 2), xk_neg.movedim(1, 2), xv_neg.movedim(1, 2),
+            self.n_local_heads, x_mask_neg, skip_reshape=True, transformer_options=transformer_options
+        )
+
+        # --- Apply NAG ONLY to Image Tokens ---
+        
+        # 1. Slice out the image part of the output
+        # sequence structure in NextDiT is typically [Image, Text] or [Text, Image]
+        # In Lumina2/NextDiT, the image is patchified first. 
+        # We assume Image tokens come first (0 to img_len).
+        
+        img_pos = out_positive[:, :img_len, :]
+        img_neg = out_negative[:, :img_len, :]
+        
+        # 2. Apply Guidance to Image tokens
+        img_guided = nag(img_pos, img_neg, self.nag_scale, self.nag_tau, self.nag_alpha)
+        
+        # 3. Keep the Positive Text tokens untouched
+        # (We discard the negative text tokens essentially, they served their purpose in Attention)
+        txt_pos = out_positive[:, img_len:, :]
+        
+        # 4. Reconstruct the guided positive sequence
+        out_guided_sequence = torch.cat([img_guided, txt_pos], dim=1)
+
+        # 5. Concatenate with full negative batch 
+        # (This is required because the wrapper expects batch size to match input, 
+        # even though we throw away the negative half later in NAGNextDiT)
+        output = torch.cat([out_guided_sequence, out_negative], dim=0)
+
+        return self.out(output)

--- a/lumina2/model.py
+++ b/lumina2/model.py
@@ -6,7 +6,6 @@ from comfy.ldm.lumina.model import NextDiT, JointAttention
 from ..utils import check_nag_activation, NAGSwitch, cat_context
 from .attention import NAGJointAttention
 
-
 class NAGNextDiT(NextDiT):
     """NAG-enabled NextDiT model for Lumina2/Z-Image"""
 
@@ -36,7 +35,7 @@ class NAGNextDiT(NextDiT):
             # 2. Prepare Inputs
             context = cat_context(context, nag_negative_context)
             x = torch.cat([x, x], dim=0)
-            
+
             if timesteps is not None:
                 timesteps = torch.cat([timesteps, timesteps], dim=0)
             if attention_mask is not None:
@@ -66,7 +65,7 @@ class NAGNextDiT(NextDiT):
             if apply_nag:
                 for mod, forward_fn in attention_forwards:
                     mod.forward = forward_fn
-                
+
                 # Cleanup
                 if "nag_img_token_len" in transformer_options:
                     del transformer_options["nag_img_token_len"]
@@ -78,23 +77,75 @@ class NAGNextDiT(NextDiT):
 
         return output
 
+
 class NAGNextDiTSwitch(NAGSwitch):
     """Switch to enable/disable NAG for NextDiT models"""
-    
+
+    def __init__(self, model, *args, **kwargs):
+        super().__init__(model, *args, **kwargs)
+        # Store original forward method for restoration
+        self.original_forward = model.forward
+        # Store original attribute states
+        self.original_attributes = {}
+
     def set_nag(self):
-        # Replace the model's forward method with NAG-enabled version
-        self.model.forward = MethodType(
-            partial(
-                NAGNextDiT.forward,
-                nag_negative_context=self.nag_negative_cond[0][0],
-                nag_sigma_end=self.nag_sigma_end,
-            ),
-            self.model
-        )
+        """Enable NAG mode on the model"""
+        # Store the negative context reference
+        self._nag_negative_context = self.nag_negative_cond[0][0]
         
+        # Create a wrapper function instead of using partial to avoid capturing tensor refs
+        def nag_forward_wrapper(model_self, *args, **kwargs):
+            return NAGNextDiT.forward(
+                model_self,
+                *args,
+                nag_negative_context=self._nag_negative_context,
+                nag_sigma_end=self.nag_sigma_end,
+                **kwargs
+            )
+        
+        # Replace the model's forward method with NAG-enabled version
+        self.model.forward = MethodType(nag_forward_wrapper, self.model)
+
         # Set NAG parameters on all JointAttention modules
         for name, module in self.model.named_modules():
             if isinstance(module, JointAttention):
+                # Store original values if they exist
+                self.original_attributes[id(module)] = {
+                    'nag_scale': getattr(module, 'nag_scale', None),
+                    'nag_tau': getattr(module, 'nag_tau', None),
+                    'nag_alpha': getattr(module, 'nag_alpha', None),
+                }
+                
+                # Set new NAG parameters
                 module.nag_scale = self.nag_scale
                 module.nag_tau = self.nag_tau
                 module.nag_alpha = self.nag_alpha
+
+    def set_origin(self):
+        """Restore original model state and clean up"""
+        super().set_origin()
+        # Restore original forward method
+        self.model.forward = self.original_forward
+        
+        # Restore or remove NAG attributes from JointAttention modules
+        for name, module in self.model.named_modules():
+            if isinstance(module, JointAttention):
+                module_id = id(module)
+                
+                # Restore original attributes or remove them
+                if module_id in self.original_attributes:
+                    orig_attrs = self.original_attributes[module_id]
+                    
+                    for attr_name in ['nag_scale', 'nag_tau', 'nag_alpha']:
+                        if orig_attrs[attr_name] is None:
+                            # Remove attribute if it didn't exist originally
+                            if hasattr(module, attr_name):
+                                delattr(module, attr_name)
+                        else:
+                            # Restore original value
+                            setattr(module, attr_name, orig_attrs[attr_name])
+        
+        # Clear stored references to help garbage collection
+        if hasattr(self, '_nag_negative_context'):
+            del self._nag_negative_context
+        self.original_attributes.clear()

--- a/lumina2/model.py
+++ b/lumina2/model.py
@@ -1,0 +1,100 @@
+from functools import partial
+from types import MethodType
+import torch
+import comfy.patcher_extension
+from comfy.ldm.lumina.model import NextDiT, JointAttention
+from ..utils import check_nag_activation, NAGSwitch, cat_context
+from .attention import NAGJointAttention
+
+
+class NAGNextDiT(NextDiT):
+    """NAG-enabled NextDiT model for Lumina2/Z-Image"""
+
+    def forward(
+        self,
+        x,
+        timesteps,
+        context,
+        num_tokens,
+        attention_mask=None,
+        nag_negative_context=None,
+        nag_sigma_end=0.,
+        **kwargs,
+    ):
+        transformer_options = kwargs.get("transformer_options", {})
+        apply_nag = check_nag_activation(transformer_options, nag_sigma_end)
+
+        attention_forwards = list()
+
+        if apply_nag:
+            # 1. Calculate Image Token Count for the Attention layer to use
+            _, _, h, w = x.shape
+            p = self.patch_size
+            img_token_len = (h // p) * (w // p)
+            transformer_options["nag_img_token_len"] = img_token_len
+
+            # 2. Prepare Inputs
+            context = cat_context(context, nag_negative_context)
+            x = torch.cat([x, x], dim=0)
+            
+            if timesteps is not None:
+                timesteps = torch.cat([timesteps, timesteps], dim=0)
+            if attention_mask is not None:
+                attention_mask = torch.cat([attention_mask, attention_mask], dim=0)
+
+            # 3. Patch Modules safely
+            for name, module in self.named_modules():
+                # Check for 'qkv' attribute to ensure we only patch actual Attention layers
+                # and strictly exclude the rope_embedder or other false positives.
+                if isinstance(module, JointAttention) and hasattr(module, "qkv"):
+                    attention_forwards.append((module, module.forward))
+                    module.forward = MethodType(NAGJointAttention.forward, module)
+
+        try:
+            # 4. Execute Model
+            output = comfy.patcher_extension.WrapperExecutor.new_class_executor(
+                self._forward,
+                self,
+                comfy.patcher_extension.get_all_wrappers(
+                    comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL,
+                    transformer_options
+                )
+            ).execute(x, timesteps, context, num_tokens, attention_mask, **kwargs)
+
+        finally:
+            # 5. Restore Original Methods (Always run this, even if crash happens)
+            if apply_nag:
+                for mod, forward_fn in attention_forwards:
+                    mod.forward = forward_fn
+                
+                # Cleanup
+                if "nag_img_token_len" in transformer_options:
+                    del transformer_options["nag_img_token_len"]
+
+        # 6. Post-process Output
+        if apply_nag and isinstance(output, torch.Tensor):
+            # Take only the first half (guided positive)
+            output = output[:output.shape[0] // 2]
+
+        return output
+
+class NAGNextDiTSwitch(NAGSwitch):
+    """Switch to enable/disable NAG for NextDiT models"""
+    
+    def set_nag(self):
+        # Replace the model's forward method with NAG-enabled version
+        self.model.forward = MethodType(
+            partial(
+                NAGNextDiT.forward,
+                nag_negative_context=self.nag_negative_cond[0][0],
+                nag_sigma_end=self.nag_sigma_end,
+            ),
+            self.model
+        )
+        
+        # Set NAG parameters on all JointAttention modules
+        for name, module in self.model.named_modules():
+            if isinstance(module, JointAttention):
+                module.nag_scale = self.nag_scale
+                module.nag_tau = self.nag_tau
+                module.nag_alpha = self.nag_alpha

--- a/samplers.py
+++ b/samplers.py
@@ -33,6 +33,7 @@ from comfy.ldm.modules.diffusionmodules.mmdit import OpenAISignatureMMDITWrapper
 from comfy.ldm.wan.model import WanModel, VaceWanModel
 from comfy.ldm.hunyuan_video.model import HunyuanVideo
 from comfy.ldm.hidream.model import HiDreamImageTransformer2DModel
+from comfy.ldm.lumina.model import NextDiT
 
 from .flux.model import NAGFluxSwitch
 from .chroma.model import NAGChromaSwitch
@@ -41,6 +42,7 @@ from .sd3.mmdit import NAGOpenAISignatureMMDITWrapperSwitch
 from .wan.model import NAGWanModelSwitch
 from .hunyuan_video.model import NAGHunyuanVideoSwitch
 from .hidream.model import NAGHiDreamImageTransformer2DModelSwitch
+from .lumina2.model import NAGNextDiTSwitch
 
 
 def sample_with_nag(
@@ -160,6 +162,8 @@ class NAGCFGGuider(CFGGuider):
                 switcher_cls = NAGWanModelSwitch
             elif model_type == HunyuanVideo:
                 switcher_cls = NAGHunyuanVideoSwitch
+            elif model_type == NextDiT:
+                switcher_cls = NAGNextDiTSwitch
             elif model_type == HiDreamImageTransformer2DModel:
                 switcher_cls = NAGHiDreamImageTransformer2DModelSwitch
             else:


### PR DESCRIPTION
Adds support for NextDiT (Lumina2/Z-Image), following existing design patterns.

Seems to work as expected. Increasing `nag_scale` above 3 or so seems to cause distortions, but it has the desired effect with:

* `nag_scale = ~1.5-2.3`
* `nag_tau = ~2.5`
* `nag_alpha = ~0.25`
* `nag_sigma_end = ~0.7-0.9`

Notably the nag_sigma_end should be increased from the default 0.0, as applying NAG to the final few steps of inference seems to reduce quality, and probably isn't needed.

Example:

<img width="1600" height="630" alt="image" src="https://github.com/user-attachments/assets/621b3aa3-db49-49ec-9704-129618cc5a1e" />

Note: I mis-captioned the text in the image. Alpha should read `0.25`, not `2.5`.

---

NOTE: if you are encountering issues with nodes not loading, you need to also apply this PR (https://github.com/ChenDarYen/ComfyUI-NAG/pull/59) to your local repo clone, OR use my fork (https://github.com/scottmudge/ComfyUI-NAG/tree/main, which includes this Z-Image support PR and that compatibility PR). 

This repo has not been updated in a while, and PR 59 fixes some compatibility issues with more recent versions of ComfyUI. 